### PR TITLE
18 new clients overwriting old clients

### DIFF
--- a/src/com/nathcat/peoplecat_server/ClientHandler.java
+++ b/src/com/nathcat/peoplecat_server/ClientHandler.java
@@ -331,9 +331,12 @@ public class ClientHandler extends ConnectionHandler {
                 ClientHandler ch = (ClientHandler) handler;
 
                 for (int userID : server.db.chatMemberships.get(chatID)) {
-                    if (userID == (int) handler.user.get("id")) {
-                        continue;
-                    }
+                    // Removing this condition will allow multiple clients connected under the same user
+                    // to receive messages from each other.
+
+                    //if (userID == (int) handler.user.get("id")) {
+                    //    continue;
+                    //}
 
                     List<ClientHandler> handlerList = ch.server.userToHandler.get(userID);
                     if (handlerList != null) handlerList.forEach((ClientHandler h) -> h.writePacket(notifyPacket));

--- a/src/com/nathcat/peoplecat_server/ClientHandler.java
+++ b/src/com/nathcat/peoplecat_server/ClientHandler.java
@@ -662,9 +662,16 @@ public class ClientHandler extends ConnectionHandler {
         if (authenticated) {
             List<ClientHandler> handlerList = server.userToHandler.get((int) user.get("id"));
 
-            handlerList.forEach((ClientHandler h) -> {
-                if (h == this) handlerList.remove((int) user.get("id"));
-            });
+            for (int i = 0; i < handlerList.size(); i++) {
+                // Presumably this comparison should determine if the handlers in question are the same handlers.
+                // I'm not sure why simply comparing the references doesn't work, but I will give this a go and
+                // see if it works.
+                // Apparantly it does indeed work now !
+                if (handlerList.get(i).threadId() == this.threadId()) {
+                    handlerList.remove(i);
+                    break;
+                }
+            }
 
             try {
                 PreparedStatement stmt = server.db.getPreparedStatement("SELECT follower FROM Friends WHERE id = ?");

--- a/src/com/nathcat/peoplecat_server/Server.java
+++ b/src/com/nathcat/peoplecat_server/Server.java
@@ -11,6 +11,8 @@ import java.net.Socket;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 
 
 public class Server {
@@ -66,7 +68,7 @@ public class Server {
         }
     }
 
-    public static final String version = "4.2.0";
+    public static final String version = "4.2.1";
 
     public int port;
     public int threadCount;
@@ -76,7 +78,7 @@ public class Server {
     /**
      * Maps a user's ID to their connected handler
      */
-    public HashMap<Integer, ClientHandler> userToHandler = new HashMap<>();
+    public HashMap<Integer, List<ClientHandler>> userToHandler = new HashMap<>();
     private Thread handlerCleaner;
 
 


### PR DESCRIPTION
Fixed issue where clients connected under the same user were being "overwritten" when new clients login with the same user (issue #18).

This was fixed by changing the user ID to handler mapping system to map to an array o active, connected, handlers all under the same user ID, rather than pointing to just a single handler.

Also removed a condition which prevented simultaneously connected clients from receiving messages from each other.