### PR TITLE
Reworked SSL configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/app/src/main/java/com/nathcat/peoplecat_database/KeyManager.java
+++ b/app/src/main/java/com/nathcat/peoplecat_database/KeyManager.java
@@ -34,8 +34,8 @@ public class KeyManager {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
     };
     private static final String KEY_FILE_PATH = "Assets/Data/Keys.json";
-    public static final String VAPID_PUBLIC_KEY_PATH = "Assets/vapid_public.pem";
-    public static final String VAPID_PRIVATE_KEY_PATH = "Assets/vapid_private.pem";
+    public static final String VAPID_PUBLIC_KEY_PATH = "Assets/SSL/vapid_public.pem";
+    public static final String VAPID_PRIVATE_KEY_PATH = "Assets/SSL/vapid_private.pem";
 
     /**
      * Get the key file, if it does not exist, initialise the key file with an empty JSON set.

--- a/app/src/main/java/com/nathcat/peoplecat_server/ConnectionHandler.java
+++ b/app/src/main/java/com/nathcat/peoplecat_server/ConnectionHandler.java
@@ -101,4 +101,8 @@ public class ConnectionHandler extends Thread {
     public boolean equals(Object obj) {
         return obj.getClass() == ConnectionHandler.class && ((ConnectionHandler) obj).threadId() == this.threadId();
     }
+
+    public long threadId() {
+        return this.getId();
+    }
 }

--- a/app/src/main/java/com/nathcat/peoplecat_server/Server.java
+++ b/app/src/main/java/com/nathcat/peoplecat_server/Server.java
@@ -82,7 +82,7 @@ public class Server {
         }
     }
 
-    public static final String version = "5.1.1";
+    public static final String version = "5.2.0";
 
     public int port;
     public int threadCount;
@@ -109,6 +109,13 @@ public class Server {
         System.setErr(getLogStream());
         
         db = new Database();
+
+        Security.addProvider(new BouncyCastleProvider());
+
+        pushService = new PushAsyncService();
+        pushServicePublicKey = KeyManager.readPublicECPEM(KeyManager.VAPID_PUBLIC_KEY_PATH);
+        pushService.setPublicKey(pushServicePublicKey);
+        pushService.setPrivateKey(KeyManager.readPrivateECPEM(KeyManager.VAPID_PRIVATE_KEY_PATH));
     }
 
     public static Options getOptions(String[] args) {
@@ -175,13 +182,6 @@ public class Server {
         // This is a small worker thread which cleans the handler array by removing inactive handlers.
         Thread cleanerThread = new HandlerCleanerThread();
         cleanerThread.start();
-
-        Security.addProvider(new BouncyCastleProvider());
-
-        pushService = new PushAsyncService();
-        pushServicePublicKey = KeyManager.readPublicECPEM(KeyManager.VAPID_PUBLIC_KEY_PATH);
-        pushService.setPublicKey(pushServicePublicKey);
-        pushService.setPrivateKey(KeyManager.readPrivateECPEM(KeyManager.VAPID_PRIVATE_KEY_PATH));
 
         ServerSocket ss = new ServerSocket(port);
 

--- a/app/src/main/java/com/nathcat/peoplecat_server/ssl/ISSLProvider.java
+++ b/app/src/main/java/com/nathcat/peoplecat_server/ssl/ISSLProvider.java
@@ -1,0 +1,7 @@
+package com.nathcat.peoplecat_server.ssl;
+
+import javax.net.ssl.SSLContext;
+
+public interface ISSLProvider {
+    SSLContext getContext();
+}

--- a/app/src/main/java/com/nathcat/peoplecat_server/ssl/LetsEncryptProvider.java
+++ b/app/src/main/java/com/nathcat/peoplecat_server/ssl/LetsEncryptProvider.java
@@ -1,0 +1,123 @@
+package com.nathcat.peoplecat_server.ssl;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.cert.Certificate;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import org.json.simple.JSONObject;
+
+import com.nathcat.peoplecat_database.KeyManager;
+
+/**
+ * Provide SSLContext from a Let's Encrypt certificate chain
+ * 
+ * @author Nathan Baines
+ */
+public class LetsEncryptProvider implements ISSLProvider {
+
+    private final JSONObject config;
+
+    /**
+     * @param sslConfig Should specify the file path of the certificate information:
+     * 
+     *                  <pre>
+     * {
+     *      "certchain-path": String,
+     *      "privatekey-path": String
+     * }
+     *                  </pre>
+     */
+    public LetsEncryptProvider(JSONObject sslConfig) {
+        config = sslConfig;
+    }
+
+    @Override
+    public SSLContext getContext() {
+        try {
+            SSLContext context = SSLContext.getInstance("TLS");
+
+
+            byte[] keyBytes = parseDERFromPEM(getBytes((String) config.get("privatekey-path")),
+                    "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----");
+
+            Certificate[] certs = getCertificateChain((String) config.get("certchain-path"));
+            PrivateKey key = generatePrivateKeyFromDER(keyBytes);
+
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+            keyStore.load(null);
+            keyStore.setCertificateEntry("cert-alias", certs[0]);
+            keyStore.setKeyEntry("key-alias", key, "pass".toCharArray(), certs);
+
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+            kmf.init(keyStore, "pass".toCharArray());
+
+            context.init(kmf.getKeyManagers(), null, null);
+            return context;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private static byte[] parseDERFromPEM(byte[] pem, String delimStart, String delimEnd) {
+        String data = new String(pem);
+        String[] tokens = data.split(delimStart);
+        tokens = tokens[1].split(delimEnd);
+        return Base64.getDecoder().decode(tokens[0].replaceAll("\n", ""));
+    }
+
+    public static PrivateKey generatePrivateKeyFromDER(byte[] key)
+            throws InvalidKeySpecException, NoSuchAlgorithmException {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(key);
+        KeyFactory f = KeyFactory.getInstance("EC");
+        return f.generatePrivate(spec);
+    }
+
+    private static X509Certificate generateCertificateFromDER(byte[] cert) throws CertificateException {
+        CertificateFactory f = CertificateFactory.getInstance("X.509");
+
+        return (X509Certificate) f.generateCertificate(new ByteArrayInputStream(cert));
+    }
+
+    private static byte[] getBytes(String path) {
+        try (FileInputStream fis = new FileInputStream(path)) {
+            return fis.readAllBytes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Certificate[] getCertificateChain(String fullChainPEM) {
+        String pem = new String(getBytes(fullChainPEM));
+
+        return Arrays.stream(pem.split("-----BEGIN CERTIFICATE-----"))
+            .filter((Object i) -> {
+                return !i.equals("");
+            })
+            .map((Object i) -> {
+                try {
+                    return generateCertificateFromDER(
+                            Base64.getDecoder().decode(
+                                    ((String) i).split("-----END CERTIFICATE-----")[0].replaceAll("\n", "")));
+                } catch (CertificateException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .toList().toArray(new Certificate[0]);
+    }
+}

--- a/app/src/main/java/com/nathcat/peoplecat_server/ssl/SSLProviderFactory.java
+++ b/app/src/main/java/com/nathcat/peoplecat_server/ssl/SSLProviderFactory.java
@@ -1,0 +1,11 @@
+package com.nathcat.peoplecat_server.ssl;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.json.simple.JSONObject;
+
+public class SSLProviderFactory {
+    public static ISSLProvider getProvider(String providerName, JSONObject config) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, ClassNotFoundException {
+        return ISSLProvider.class.cast(Class.forName("com.nathcat.peoplecat_server.ssl." + providerName).getDeclaredConstructor(JSONObject.class).newInstance(config));
+    }
+}


### PR DESCRIPTION
# SSL Configuration rework

The configuration system for the server's SSL feature has been reworked, the following is the new format for the `Assets/SSL_Config.json` file which specifies the config for the server's SSL execution.

```json
{
  "ssl-provider": String,
  "privatekey-path": String,
  "certchain-path": String
}
```

The `ssl-provider` field should specify the name of a class within the package `com.nathcat.peoplecat_server.ssl` which implements the `ISSLProvider` interface. Such classes provide specific ways to obtain an `SSLContext` which the server can use. Currently the only one which exists is `LetsEncryptProvider`, which should be used with LetsEncrypt certificates which have an `EC` private key.

`privatekey-path` should be the path to the private key for the server's certificate.

`certchain-path` should be the path to the full public certificate chain.